### PR TITLE
Update for Anki 2.1.49+

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ check media also removes the tag «MissingMedia» from notes which does
 not have a missing media. So that if you have corrected a note, it
 does not appear anymore when you search for notes with Missing Media.
 ## Internal
-It totally redefines the method `anki.media.MediaManager.check`. So
+It totally redefines the method `aqt.mediacheck.MediaChecker.check`. So
 this add-on is incompatible with any other add-on changing this
 method.
 

--- a/__init__.py
+++ b/__init__.py
@@ -32,10 +32,10 @@ def on_finished(self: MediaChecker, fut: Future) -> None:
     CollectionOp(parent=mw, op=task).success(on_success).run_in_background()
 
 
-def on_check(self: MediaChecker) -> None:
+def check(self: MediaChecker) -> None:
     self.progress_dialog = self.mw.progress.start()
     self._set_progress_enabled(True)
     self.mw.taskman.run_in_background(self._check, lambda fut: on_finished(self, fut))
 
 
-MediaChecker.check = on_check
+MediaChecker.check = check

--- a/__init__.py
+++ b/__init__.py
@@ -1,121 +1,30 @@
-from anki.media import *
-from anki.notes import Note
-from aqt import mw, dialogs
-from anki.find import Finder
+from concurrent.futures import Future
+from aqt.mediacheck import MediaChecker
+from aqt import mw
+from aqt.utils import tooltip
 
-# oldCheck = MediaManager.check
-# def check(self, local=None):
-#     (missingFiles, unusedFiles) = oldCheck(self, local)
-#     nids = set()
-#     query = """select id from notes where flds like "" """
-
-def check(self, local=None):
-    "Return (missingFiles, unusedFiles)."
-    mdir = self.dir()
-    # gather all media references in NFC form
-    allRefs = set()
-    refsToNid = dict() # this dic is new
-    for nid, mid, flds in self.col.db.execute("select id, mid, flds from notes"):
-        noteRefs = self.filesInStr(mid, flds)
-        # check the refs are in NFC
-        for f in noteRefs:
-            # if they're not, we'll need to fix them first
-            if f != unicodedata.normalize("NFC", f):
-                self._normalizeNoteRefs(nid)
-                noteRefs = self.filesInStr(mid, flds)
-                break
-        # new. update refsToNid
-        for f in noteRefs:
-            if f not in refsToNid:
-                refsToNid[f] = set()
-            refsToNid[f].add(nid)
-        # end new
-        allRefs.update(noteRefs)
-    # loop through media folder
-    unused = []
-    if local is None:
-        files = os.listdir(mdir)
-    else:
-        files = local
-    renamedFiles = False
-    dirFound = False
-    warnings = []
-    for file in files:
-        if not local:
-            if not os.path.isfile(file):
-                # ignore directories
-                dirFound = True
-                continue
-        if file.startswith("_"):
-            # leading _ says to ignore file
-            continue
-
-        if self.hasIllegal(file):
-            name = file.encode(sys.getfilesystemencoding(), errors="replace")
-            name = str(name, sys.getfilesystemencoding())
-            warnings.append(
-                _("Invalid file name, please rename: %s") % name)
-            continue
-
-        nfcFile = unicodedata.normalize("NFC", file)
-        # we enforce NFC fs encoding on non-macs
-        if not isMac and not local:
-            if file != nfcFile:
-                # delete if we already have the NFC form, otherwise rename
-                if os.path.exists(nfcFile):
-                    os.unlink(file)
-                    renamedFiles = True
-                else:
-                    os.rename(file, nfcFile)
-                    renamedFiles = True
-                file = nfcFile
-        # compare
-        if nfcFile not in allRefs:
-            unused.append(file)
-        else:
-            allRefs.discard(nfcFile)
-    # if we renamed any files to nfc format, we must rerun the check
-    # to make sure the renamed files are not marked as unused
-    if renamedFiles:
-        return self.check(local=local)
-    # NEW: A line here removed because it was a bug
-    # New
-    finder = Finder(mw.col)
-    alreadyMissingNids = finder.findNotes("tag:MissingMedia")
-    nidsOfMissingRefs = set()
-    for ref in allRefs:
-        nidsOfMissingRefs.update(refsToNid[ref])
-        #print(f"nidsOfMissingRefs is now {nidsOfMissingRefs}")
-
-    for nid in nidsOfMissingRefs:
-        if nid not in alreadyMissingNids:
-            print(f"missing nid {nid}")
-            note = Note(mw.col, id = nid)
-            note.addTag("MissingMedia")
-            note.flush()
-
-    for nid in alreadyMissingNids:
-        if nid not in nidsOfMissingRefs:
-            print(f"not missing anymore nid {nid}")
-            note = Note(mw.col, id = nid)
-            note.delTag("MissingMedia")
-            note.flush()
-    # end new
-
-    # make sure the media DB is valid
-    try:
-        self.findChanges()
-    except DBError:
-        self._deleteDB()
-    if dirFound:
-        warnings.append(
-            _("Anki does not support files in subfolders of the collection.media folder."))
-    if allRefs:
-        browser = dialogs.open("Browser", mw)
-        browser.form.searchEdit.lineEdit().setText("tag:MissingMedia")
-        browser.onSearchActivated()
-    return (allRefs, unused, warnings)
+TAGNAME = "MissingMedia"
 
 
+def on_finished(self: MediaChecker, fut: Future) -> None:
+    self._on_finished(fut)
+    output = fut.result()
+    missing = output.missing
+    mw.col.tags.remove(TAGNAME)
+    nids = []
+    for filename in missing:
+        for nid, mid, flds in mw.col.db.execute("select id, mid, flds from notes"):
+            media_refs = mw.col.media.filesInStr(mid, flds)
+            if filename in media_refs:
+                nids.append(nid)
+    mw.col.tags.bulkAdd(nids, TAGNAME)
+    tooltip(f"Tagged {len(nids)} notes with {TAGNAME}")
 
-MediaManager.check = check
+
+def on_check(self: MediaChecker) -> None:
+    self.progress_dialog = self.mw.progress.start()
+    self._set_progress_enabled(True)
+    self.mw.taskman.run_in_background(self._check, lambda fut: on_finished(self, fut))
+
+
+MediaChecker.check = on_check

--- a/__init__.py
+++ b/__init__.py
@@ -1,5 +1,6 @@
 from concurrent.futures import Future
 
+import aqt
 from aqt import mw
 from aqt.mediacheck import MediaChecker
 from aqt.utils import tooltip, showWarning
@@ -52,6 +53,7 @@ def on_finished(self: MediaChecker, fut: Future) -> None:
         try:
             count = fut.result()
             tooltip(f"Tagged {count} notes with {TAGNAME}", parent=mw)
+            aqt.dialogs.open("Browser", mw=mw, search=(f"tag:{TAGNAME}",))
         except Exception as exc:
             showWarning(str(exc), title=ADDON_NAME)
         finally:

--- a/__init__.py
+++ b/__init__.py
@@ -17,7 +17,7 @@ def on_finished(self: MediaChecker, fut: Future) -> None:
         col = mw.col
         col.tags.remove(TAGNAME)
         total = mw.col.note_count()
-        progress_step = max(100, min(1000, total / 100))
+        progress_step = max(100, min(1000, total // 100))
         count = 0
         tagged_nids = []
         want_cancel = False

--- a/__init__.py
+++ b/__init__.py
@@ -51,7 +51,7 @@ def on_finished(self: MediaChecker, fut: Future) -> None:
     def on_done(fut: Future):
         try:
             count = fut.result()
-            tooltip(f"Tagged {count} notes with {TAGNAME}")
+            tooltip(f"Tagged {count} notes with {TAGNAME}", parent=mw)
         except Exception as exc:
             showWarning(str(exc), title=ADDON_NAME)
         finally:


### PR DESCRIPTION
This updates the add-on to work on Anki 2.1.49+.

My changes include the following:
- Patch MediaChecker.check. The patch can be eliminated completely when the [media_check_did_finish](https://github.com/ankitects/anki/pull/1889) becomes available.
- Run the add-on's operations in the background and show progress and a tooltip at the end showing how many notes were tagged.
- Use new functions to add/remove tags in bulk.

## TODO
- [x] Update the [docs](https://github.com/Arthur-Milchior/anki-tag-missing-medias#internal).
- [x] Open the browser window with the tagged notes shown (I didn't notice there is such a functionality in the add-on when I rewrote it). If we use the new hook in the future, it may make more sense to not add this back, as the hook will run before the Check Media screen is shown, and can be distracting in this case.

One idea I would like to suggest is to make the add-on work via a button added to the Check Media screen instead of making it run all the time.
